### PR TITLE
Add disable-security-hub.sh script with proper error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ aws-sec/
 │   └── master/
 ├── aws-scripts/              # Security Hub automation scripts
 │   ├── enable-security-hub.sh
+│   ├── disable-security-hub.sh
 │   ├── get-findings.sh
 │   ├── get-critical-findings.sh
 │   ├── get-compliance-summary.sh
@@ -165,11 +166,24 @@ Inside any container, you can run the following scripts:
    ./remediate-findings.sh
    ```
 
+7. **Disable Security Hub**
+   ```bash
+   ./disable-security-hub.sh
+   ```
+
 ## Scripts Description
 
 ### enable-security-hub.sh
 - Enables AWS Security Hub if not already enabled
 - Activates major compliance standards (AWS Foundational Security Best Practices, CIS, PCI-DSS)
+
+### disable-security-hub.sh
+- Checks Security Hub status before attempting cleanup
+- Disables all enabled security standards (CIS, PCI-DSS, AWS Foundational Security Best Practices)
+- Removes and disassociates member accounts from Security Hub
+- Cleans up custom insights and action targets
+- Safely disables Security Hub with proper error handling
+- Provides detailed status updates throughout the process
 
 ### get-findings.sh
 - Retrieves all Security Hub findings

--- a/aws-scripts/disable-security-hub.sh
+++ b/aws-scripts/disable-security-hub.sh
@@ -1,26 +1,134 @@
 #!/bin/bash
 
 # This script deactivates AWS Security Hub and cleans up resources in the specified AWS account.
+# It handles cases where Security Hub is not enabled and provides proper error handling.
 
-function disable_security_hub() {
-    echo "Disabling AWS Security Hub for account..."
-    aws securityhub disable-security-hub
+set -e  # Exit on any error
 
-    echo "Deleting Security Hub member accounts..."
-    ACCOUNT_IDS=$(aws securityhub list-members --only-associated | jq -r '.Members[].AccountId')
-    if [ -n "$ACCOUNT_IDS" ]; then
-        aws securityhub disassociate-members --account-ids $ACCOUNT_IDS
-        aws securityhub delete-members --account-ids $ACCOUNT_IDS
+function check_security_hub_status() {
+    echo "Checking Security Hub status..."
+    if aws securityhub describe-hub >/dev/null 2>&1; then
+        echo "Security Hub is enabled."
+        return 0
+    else
+        echo "Security Hub is not enabled or not accessible."
+        return 1
+    fi
+}
+
+function disable_standards() {
+    echo "Disabling Security Hub standards..."
+    
+    # Get enabled standards
+    STANDARDS=$(aws securityhub get-enabled-standards --output text --query 'StandardsSubscriptions[].StandardsSubscriptionArn' 2>/dev/null || echo "")
+    
+    if [ -n "$STANDARDS" ]; then
+        for standard in $STANDARDS; do
+            echo "Disabling standard: $standard"
+            aws securityhub batch-disable-standards --standards-subscription-arns "$standard" >/dev/null 2>&1 || echo "Failed to disable standard: $standard"
+        done
+    else
+        echo "No enabled standards found."
+    fi
+}
+
+function cleanup_members() {
+    echo "Cleaning up Security Hub member accounts..."
+    
+    # Get member accounts (without using jq)
+    MEMBERS_OUTPUT=$(aws securityhub list-members --only-associated --output text --query 'Members[].AccountId' 2>/dev/null || echo "")
+    
+    if [ -n "$MEMBERS_OUTPUT" ] && [ "$MEMBERS_OUTPUT" != "None" ]; then
+        echo "Found member accounts, disassociating and deleting..."
+        for account_id in $MEMBERS_OUTPUT; do
+            echo "Disassociating member account: $account_id"
+            aws securityhub disassociate-members --account-ids "$account_id" >/dev/null 2>&1 || echo "Failed to disassociate: $account_id"
+            
+            echo "Deleting member account: $account_id"
+            aws securityhub delete-members --account-ids "$account_id" >/dev/null 2>&1 || echo "Failed to delete: $account_id"
+        done
     else
         echo "No member accounts found."
     fi
-
-    echo "Cleaning up findings..."
-    aws securityhub delete-insight --insight-arn $(aws securityhub list-insights | jq -r '.Insights[].InsightArn')
-    aws securityhub delete-action-target --action-target-arn $(aws securityhub list-action-targets | jq -r '.ActionTargets[].ActionTargetArn')
-
-    echo "AWS Security Hub has been deactivated and resources have been cleaned up."
 }
 
-# Execute the function
-disable_security_hub
+function cleanup_insights() {
+    echo "Cleaning up Security Hub insights..."
+    
+    # Get insights (without using jq)
+    INSIGHTS=$(aws securityhub get-insights --output text --query 'Insights[].InsightArn' 2>/dev/null || echo "")
+    
+    if [ -n "$INSIGHTS" ] && [ "$INSIGHTS" != "None" ]; then
+        for insight_arn in $INSIGHTS; do
+            echo "Deleting insight: $insight_arn"
+            aws securityhub delete-insight --insight-arn "$insight_arn" >/dev/null 2>&1 || echo "Failed to delete insight: $insight_arn"
+        done
+    else
+        echo "No insights found."
+    fi
+}
+
+function cleanup_action_targets() {
+    echo "Cleaning up Security Hub action targets..."
+    
+    # Get action targets (without using jq)
+    ACTION_TARGETS=$(aws securityhub describe-action-targets --output text --query 'ActionTargets[].ActionTargetArn' 2>/dev/null || echo "")
+    
+    if [ -n "$ACTION_TARGETS" ] && [ "$ACTION_TARGETS" != "None" ]; then
+        for target_arn in $ACTION_TARGETS; do
+            echo "Deleting action target: $target_arn"
+            aws securityhub delete-action-target --action-target-arn "$target_arn" >/dev/null 2>&1 || echo "Failed to delete action target: $target_arn"
+        done
+    else
+        echo "No action targets found."
+    fi
+}
+
+function disable_security_hub() {
+    echo "Disabling AWS Security Hub..."
+    
+    if aws securityhub disable-security-hub >/dev/null 2>&1; then
+        echo "Security Hub has been successfully disabled."
+    else
+        echo "Failed to disable Security Hub or it was already disabled."
+    fi
+}
+
+function main() {
+    echo "=== AWS Security Hub Cleanup Script ==="
+    echo "This script will disable Security Hub and clean up all related resources."
+    echo ""
+    
+    # Check if Security Hub is enabled
+    if check_security_hub_status; then
+        echo "Proceeding with Security Hub cleanup..."
+        echo ""
+        
+        # Disable standards first
+        disable_standards
+        echo ""
+        
+        # Clean up member accounts
+        cleanup_members
+        echo ""
+        
+        # Clean up insights
+        cleanup_insights
+        echo ""
+        
+        # Clean up action targets
+        cleanup_action_targets
+        echo ""
+        
+        # Finally disable Security Hub
+        disable_security_hub
+        echo ""
+        
+        echo "=== Security Hub cleanup completed ==="
+    else
+        echo "Security Hub is not enabled. No cleanup required."
+    fi
+}
+
+# Execute the main function
+main

--- a/aws-scripts/disable-security-hub.sh
+++ b/aws-scripts/disable-security-hub.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script deactivates AWS Security Hub and cleans up resources in the specified AWS account.
+
+function disable_security_hub() {
+    echo "Disabling AWS Security Hub for account..."
+    aws securityhub disable-security-hub
+
+    echo "Deleting Security Hub member accounts..."
+    ACCOUNT_IDS=$(aws securityhub list-members --only-associated | jq -r '.Members[].AccountId')
+    if [ -n "$ACCOUNT_IDS" ]; then
+        aws securityhub disassociate-members --account-ids $ACCOUNT_IDS
+        aws securityhub delete-members --account-ids $ACCOUNT_IDS
+    else
+        echo "No member accounts found."
+    fi
+
+    echo "Cleaning up findings..."
+    aws securityhub delete-insight --insight-arn $(aws securityhub list-insights | jq -r '.Insights[].InsightArn')
+    aws securityhub delete-action-target --action-target-arn $(aws securityhub list-action-targets | jq -r '.ActionTargets[].ActionTargetArn')
+
+    echo "AWS Security Hub has been deactivated and resources have been cleaned up."
+}
+
+# Execute the function
+disable_security_hub


### PR DESCRIPTION
## Description

This PR adds a new script to safely disable AWS Security Hub and clean up all related resources.

## Changes Added

### New Script: 
- **Status checking**: Verifies Security Hub is enabled before attempting cleanup
- **Standards cleanup**: Properly disables all enabled security standards (CIS, PCI-DSS, AWS Foundational Security Best Practices)
- **Member account cleanup**: Removes and disassociates member accounts from Security Hub
- **Insights cleanup**: Removes custom insights
- **Action targets cleanup**: Removes custom action targets
- **Comprehensive error handling**: Continues execution even if individual steps fail
- **Detailed logging**: Shows progress and status for each operation

### Technical Improvements
- **No jq dependency**: Uses AWS CLI native --query parameter with --output text
- **Correct AWS CLI commands**: Fixed command names (get-insights vs list-insights)
- **Proper error handling**: Gracefully handles cases where Security Hub is not enabled
- **Modular structure**: Split into logical functions for better organization

### Documentation Updates
- Updated README.md with new script documentation
- Added usage examples and script description
- Updated project structure to include the new script

## Usage
```bash
# Access any container
docker-compose exec awscli-account1 bash

# Run the disable script
./disable-security-hub.sh
```

## Testing
- [x] Script tested without jq dependency
- [x] Error handling verified for disabled Security Hub
- [x] All AWS CLI commands validated
- [x] Documentation updated and verified
- [x] Script made executable